### PR TITLE
 Move deps to dev-2.2 from temp 2.2.5 dev

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
 {erl_opts, [debug_info, warnings_as_errors]}.
 {deps, [
-        {riak_pb, "2.2.*", {git, "git://github.com/basho/riak_pb.git", {tag, "2.2.0.0"}}}
+        {riak_pb, "2.2.*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
 {erl_opts, [debug_info, warnings_as_errors]}.
 {deps, [
-        {riak_pb, "2.2.*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}}
+        {riak_pb, "2.2.*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2"}}}
        ]}.


### PR DESCRIPTION
As part of setting up for the 2.2.5 release I made a temp branch off the
last released tag, this takes that branch back into the branch the tag
was cut from.